### PR TITLE
Java 17 update

### DIFF
--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <parent>
+    <artifactId>slingr-services-builder</artifactId>
+    <groupId>io.github.slingr-stack</groupId>
+    <version>1.0.0</version>
+    <relativePath>../pom.xml/pom.xml</relativePath>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>pdf</artifactId>
+  <name>SLINGR - PDF service</name>
+  <version>1.0-SNAPSHOT</version>
+  <description>Default component to convert html to pdf or images of the Slingr platform</description>
+  <repositories>
+    <repository>
+      <id>clojars</id>
+      <name>Clojars repository</name>
+      <url>https://clojars.org/repo</url>
+    </repository>
+  </repositories>
+  <dependencies>
+    <dependency>
+      <groupId>com.itextpdf</groupId>
+      <artifactId>itext-core</artifactId>
+      <version>8.0.2</version>
+      <type>pom</type>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+  <properties>
+    <pdfbox.version>3.0.1</pdfbox.version>
+    <build.main-class>io.slingr.service.pdf.Runner</build.main-class>
+    <jsoup.version>1.17.2</jsoup.version>
+    <itext.version>8.0.2</itext.version>
+    <slingr.slingr-service.version>1.4.0</slingr.slingr-service.version>
+    <freemarker.version>2.3.32</freemarker.version>
+  </properties>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>io.slingr.services</groupId>
+    <parent>
+        <groupId>io.github.slingr-stack</groupId>
+        <artifactId>slingr-services-builder</artifactId>
+        <version>1.0.0</version>
+    </parent>
     <artifactId>pdf</artifactId>
     <version>1.0-SNAPSHOT</version>
     <name>SLINGR - PDF service</name>
@@ -9,15 +13,13 @@
     <packaging>jar</packaging>
     <properties>
         <!-- Slingr versions -->
-        <slingr.slingr-service.version>1.2-SNAPSHOT</slingr.slingr-service.version>
+        <slingr.slingr-service.version>1.4.0</slingr.slingr-service.version>
+        <!-- Dependency versions -->
+        <freemarker.version>2.3.32</freemarker.version>
+        <pdfbox.version>3.0.1</pdfbox.version>
+        <jsoup.version>1.17.2</jsoup.version>
+        <itext.version>8.0.2</itext.version>
         <!-- Build properties -->
-        <jdk.version>11</jdk.version>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.build.compiler.version>2.5.1</project.build.compiler.version>
-        <project.build.source.version>3.0.1</project.build.source.version>
-        <project.build.shade.version>2.4.1</project.build.shade.version>
-        <project.build.s3-wagon.version>3.3</project.build.s3-wagon.version>
-        <!-- Other properties -->
         <build.main-class>io.slingr.service.pdf.Runner</build.main-class>
     </properties>
     <dependencies>
@@ -32,131 +34,30 @@
         <dependency>
             <groupId>org.freemarker</groupId>
             <artifactId>freemarker</artifactId>
-            <version>2.3.32</version>
+            <version>${freemarker.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.pdfbox</groupId>
             <artifactId>pdfbox</artifactId>
-            <version>2.0.29</version>
+            <version>${pdfbox.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
-            <version>1.16.1</version>
+            <version>${jsoup.version}</version>
         </dependency>
-        <!--suppress VulnerableLibrariesLocal -->
         <dependency>
             <groupId>com.itextpdf</groupId>
-            <artifactId>itext7-core</artifactId>
-            <version>7.1.18</version>
+            <artifactId>itext-core</artifactId>
+            <version>${itext.version}</version>
             <type>pom</type>
         </dependency>
     </dependencies>
     <repositories>
-        <repository>
-            <id>Central</id>
-            <name>Central</name>
-            <url>https://repo1.maven.org/maven2/</url>
-            <layout>default</layout>
-        </repository>
-        <repository>
-            <id>slingrRepo.release</id>
-            <url>http://repo.slingrs.io/release</url>
-            <releases>
-                <enabled>true</enabled>
-                <checksumPolicy>fail</checksumPolicy>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-        <repository>
-            <id>slingrRepo.snapshot</id>
-            <url>http://repo.slingrs.io/snapshot</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-                <checksumPolicy>warn</checksumPolicy>
-            </snapshots>
-        </repository>
         <repository>
             <id>clojars</id>
             <name>Clojars repository</name>
             <url>https://clojars.org/repo</url>
         </repository>
     </repositories>
-    <distributionManagement>
-        <repository>
-            <id>slingrRepo.write.release</id>
-            <url>gs://repo.slingrs.io/release</url>
-        </repository>
-        <snapshotRepository>
-            <id>clojars</id>
-            <name>Clojars repository</name>
-            <url>https://clojars.org/repo</url>
-        </snapshotRepository>
-    </distributionManagement>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>${project.build.compiler.version}</version>
-                <configuration>
-                    <source>${jdk.version}</source>
-                    <target>${jdk.version}</target>
-                    <encoding>${project.build.sourceEncoding}</encoding>
-                </configuration>
-            </plugin>
-            <!--
-            This plugin is use to generate the JAR with all the dependencies, which is needed
-            when deploying the service in the platform (not development mode).
-            -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>${project.build.shade.version}</version>
-                <configuration>
-                    <shadedArtifactAttached>true</shadedArtifactAttached>
-                    <shadedClassifierName>jar-with-dependencies</shadedClassifierName>
-                    <transformers>
-                        <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
-                        <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                            <manifestEntries>
-                                <Main-Class>${build.main-class}</Main-Class>
-                                <X-Compile-Source-JDK>${jdk.version}</X-Compile-Source-JDK>
-                                <X-Compile-Target-JDK>${jdk.version}</X-Compile-Target-JDK>
-                            </manifestEntries>
-                        </transformer>
-                        <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer">
-                            <addHeader>false</addHeader>
-                        </transformer>
-                        <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"></transformer>
-                    </transformers>
-                    <filters>
-                        <filter>
-                            <artifact>*:*</artifact>
-                            <excludes>
-                                <exclude>META-INF/services/org/apache/camel/component.properties</exclude>
-                                <exclude>META-INF/services/org/apache/camel/dataformat.properties</exclude>
-                                <exclude>META-INF/*.SF</exclude>
-                                <exclude>META-INF/*.DSA</exclude>
-                                <exclude>META-INF/*.RSA</exclude>
-                            </excludes>
-                        </filter>
-                    </filters>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/public_pom.xml
+++ b/public_pom.xml
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>io.slingr.services</groupId>
+    <parent>
+        <groupId>io.github.slingr-stack</groupId>
+        <artifactId>slingr-services-builder</artifactId>
+        <version>1.0.0</version>
+    </parent>
     <artifactId>pdf</artifactId>
     <version>1.0-SNAPSHOT</version>
     <name>SLINGR - PDF service</name>
@@ -9,15 +13,13 @@
     <packaging>jar</packaging>
     <properties>
         <!-- Slingr versions -->
-        <slingr.slingr-service.version>1.2-SNAPSHOT</slingr.slingr-service.version>
+        <slingr.slingr-service.version>1.4.0</slingr.slingr-service.version>
+        <!-- Dependency versions -->
+        <freemarker.version>2.3.32</freemarker.version>
+        <pdfbox.version>3.0.1</pdfbox.version>
+        <jsoup.version>1.17.2</jsoup.version>
+        <itext.version>8.0.2</itext.version>
         <!-- Build properties -->
-        <jdk.version>11</jdk.version>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.build.compiler.version>2.5.1</project.build.compiler.version>
-        <project.build.source.version>3.0.1</project.build.source.version>
-        <project.build.shade.version>2.4.1</project.build.shade.version>
-        <project.build.s3-wagon.version>3.3</project.build.s3-wagon.version>
-        <!-- Other properties -->
         <build.main-class>io.slingr.service.pdf.Runner</build.main-class>
     </properties>
     <dependencies>
@@ -32,131 +34,30 @@
         <dependency>
             <groupId>org.freemarker</groupId>
             <artifactId>freemarker</artifactId>
-            <version>2.3.32</version>
+            <version>${freemarker.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.pdfbox</groupId>
             <artifactId>pdfbox</artifactId>
-            <version>2.0.29</version>
+            <version>${pdfbox.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
-            <version>1.16.1</version>
+            <version>${jsoup.version}</version>
         </dependency>
-        <!--suppress VulnerableLibrariesLocal -->
         <dependency>
             <groupId>com.itextpdf</groupId>
-            <artifactId>itext7-core</artifactId>
-            <version>7.1.18</version>
+            <artifactId>itext-core</artifactId>
+            <version>${itext.version}</version>
             <type>pom</type>
         </dependency>
     </dependencies>
     <repositories>
-        <repository>
-            <id>Central</id>
-            <name>Central</name>
-            <url>https://repo1.maven.org/maven2/</url>
-            <layout>default</layout>
-        </repository>
-        <repository>
-            <id>slingrRepo.release</id>
-            <url>http://repo.slingrs.io/release</url>
-            <releases>
-                <enabled>true</enabled>
-                <checksumPolicy>fail</checksumPolicy>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-        <repository>
-            <id>slingrRepo.snapshot</id>
-            <url>http://repo.slingrs.io/snapshot</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-                <checksumPolicy>warn</checksumPolicy>
-            </snapshots>
-        </repository>
         <repository>
             <id>clojars</id>
             <name>Clojars repository</name>
             <url>https://clojars.org/repo</url>
         </repository>
     </repositories>
-    <distributionManagement>
-        <repository>
-            <id>slingrRepo.write.release</id>
-            <url>gs://repo.slingrs.io/release</url>
-        </repository>
-        <snapshotRepository>
-            <id>clojars</id>
-            <name>Clojars repository</name>
-            <url>https://clojars.org/repo</url>
-        </snapshotRepository>
-    </distributionManagement>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>${project.build.compiler.version}</version>
-                <configuration>
-                    <source>${jdk.version}</source>
-                    <target>${jdk.version}</target>
-                    <encoding>${project.build.sourceEncoding}</encoding>
-                </configuration>
-            </plugin>
-            <!--
-            This plugin is use to generate the JAR with all the dependencies, which is needed
-            when deploying the service in the platform (not development mode).
-            -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>${project.build.shade.version}</version>
-                <configuration>
-                    <shadedArtifactAttached>true</shadedArtifactAttached>
-                    <shadedClassifierName>jar-with-dependencies</shadedClassifierName>
-                    <transformers>
-                        <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
-                        <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                            <manifestEntries>
-                                <Main-Class>${build.main-class}</Main-Class>
-                                <X-Compile-Source-JDK>${jdk.version}</X-Compile-Source-JDK>
-                                <X-Compile-Target-JDK>${jdk.version}</X-Compile-Target-JDK>
-                            </manifestEntries>
-                        </transformer>
-                        <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer">
-                            <addHeader>false</addHeader>
-                        </transformer>
-                        <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"></transformer>
-                    </transformers>
-                    <filters>
-                        <filter>
-                            <artifact>*:*</artifact>
-                            <excludes>
-                                <exclude>META-INF/services/org/apache/camel/component.properties</exclude>
-                                <exclude>META-INF/services/org/apache/camel/dataformat.properties</exclude>
-                                <exclude>META-INF/*.SF</exclude>
-                                <exclude>META-INF/*.DSA</exclude>
-                                <exclude>META-INF/*.RSA</exclude>
-                            </excludes>
-                        </filter>
-                    </filters>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/src/main/java/io/slingr/service/pdf/Pdf.java
+++ b/src/main/java/io/slingr/service/pdf/Pdf.java
@@ -18,6 +18,8 @@ import io.slingr.services.utils.FilesUtils;
 import io.slingr.services.utils.Json;
 import io.slingr.services.ws.exchange.FunctionRequest;
 import org.apache.commons.lang.StringUtils;
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.io.RandomAccessReadBuffer;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.rendering.ImageType;
 import org.apache.pdfbox.rendering.PDFRenderer;
@@ -103,13 +105,13 @@ public class Pdf extends Service {
             is = pdfEngine.getPDF();
             if (is != null) {
                 try {
-                    logger.info("Uploading file to endpoint services");
+                    logger.info("Uploading file to platform");
                     Json fileJson = files().upload(pdfEngine.getFileName(), is, "application/pdf");
-                    logger.info("Done uploading file to endpoint services");
+                    logger.info("Done uploading file to platform");
                     res.set("status", "ok");
                     res.set("file", fileJson);
                 } catch (Exception e) {
-                    logger.error("Problems uploading file to endpoint services", e);
+                    logger.error("Problems uploading file to platform", e);
                     if (retry) {
                         logger.info("Retrying uploading");
                         createPdf(req, false);
@@ -285,7 +287,7 @@ public class Pdf extends Service {
                 List<String> ids = new ArrayList<>();
                 try {
                     logger.info("Converting pdf to images");
-                    PDDocument document = PDDocument.load(file.getFile());
+                    PDDocument document = Loader.loadPDF(new RandomAccessReadBuffer(file.getFile()));
                     PDFRenderer pdfRenderer = new PDFRenderer(document);
                     for (int page = 0; page < document.getNumberOfPages(); ++page) {
                         BufferedImage bim = pdfRenderer.renderImageWithDPI(page, dpi, ImageType.RGB);

--- a/src/main/java/io/slingr/service/pdf/processors/PdfFillForm.java
+++ b/src/main/java/io/slingr/service/pdf/processors/PdfFillForm.java
@@ -10,6 +10,7 @@ import com.itextpdf.kernel.font.PdfFontFactory;
 import com.itextpdf.kernel.pdf.PdfDocument;
 import com.itextpdf.kernel.pdf.PdfReader;
 import com.itextpdf.kernel.pdf.PdfWriter;
+import com.itextpdf.layout.properties.TextAlignment;
 import io.slingr.services.services.AppLogs;
 import io.slingr.services.services.Files;
 import io.slingr.services.utils.Json;
@@ -100,19 +101,19 @@ public class PdfFillForm {
                                     formField.setFontSize(fieldSettings.integer("textSize"));
                                 }
                                 if (fieldSettings.contains("backgroundColor")) {
-                                    formField.setBackgroundColor(hex2Rgb(fieldSettings.string("backgroundColor")));
+                                    formField.getFirstFormAnnotation().setBackgroundColor(hex2Rgb(fieldSettings.string("backgroundColor")));
                                 }
                                 if (fieldSettings.contains("textColor")) {
                                     formField.setColor(hex2Rgb(fieldSettings.string("textColor")));
                                 }
                                 if (fieldSettings.contains("textAlignment")) {
-                                    int textAlign = PdfFormField.ALIGN_LEFT;
+                                    TextAlignment alignment = TextAlignment.LEFT;
                                     if ("CENTER".equals(fieldSettings.string("textAlignment"))) {
-                                        textAlign = PdfFormField.ALIGN_CENTER;
+                                        alignment = TextAlignment.CENTER;
                                     } else if ("RIGHT".equals(fieldSettings.string("textAlignment"))) {
-                                        textAlign = PdfFormField.ALIGN_RIGHT;
+                                        alignment = TextAlignment.RIGHT;
                                     }
-                                    formField.setJustification(textAlign);
+                                    formField.setJustification(alignment);
                                 }
                                 boolean readOnly = false;
                                 if (fieldSettings.contains("readOnly")) {

--- a/src/main/java/io/slingr/service/pdf/processors/PdfHeaderFooterHandler.java
+++ b/src/main/java/io/slingr/service/pdf/processors/PdfHeaderFooterHandler.java
@@ -7,6 +7,8 @@ import io.slingr.services.utils.Json;
 import io.slingr.services.utils.Strings;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.io.RandomAccessReadBuffer;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.PDPageContentStream;
@@ -40,7 +42,7 @@ public class PdfHeaderFooterHandler {
         if (footerTemplate != null) {
             tempFiles.put(FOOTER_HTML_PATH, getTempFileFromTemplate(footerTemplate));
         }
-        try (final PDDocument document = PDDocument.load(report)) {
+        try (final PDDocument document = Loader.loadPDF(new RandomAccessReadBuffer(report))) {
             File tempHeader = getImageFromTemplate(tempFiles.get(HEADER_HTML_PATH), document, hHeight);
             if (tempHeader != null) {
                 tempFiles.put(TEMP_HEADER_PATH, tempHeader.getPath());
@@ -103,7 +105,7 @@ public class PdfHeaderFooterHandler {
     }
 
     public String setHeaderWithImage(InputStream report, InputStream header, float hHeight, float hWidth, InputStream footer, int fHeight, float fWidth) {
-        try (final PDDocument document = PDDocument.load(report)) {
+        try (final PDDocument document = Loader.loadPDF(new RandomAccessReadBuffer(report))) {
             File tempHeader = null;
             if (header != null) {
                 tempHeader = getImageFromInputStream(header);

--- a/src/main/java/io/slingr/service/pdf/workers/AddImagesWorker.java
+++ b/src/main/java/io/slingr/service/pdf/workers/AddImagesWorker.java
@@ -7,6 +7,8 @@ import io.slingr.services.services.Files;
 import io.slingr.services.services.rest.DownloadedFile;
 import io.slingr.services.utils.Json;
 import io.slingr.services.ws.exchange.FunctionRequest;
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.io.RandomAccessReadBuffer;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.PDPageContentStream;
@@ -35,7 +37,7 @@ public class AddImagesWorker extends PdfImageWorker {
         Json res = Json.map();
         try {
             InputStream is = files.download(fileId).getFile();
-            PDDocument pdf = PDDocument.load(is);
+            PDDocument pdf = Loader.loadPDF(new RandomAccessReadBuffer(is));
             Json settings = data.json("settings");
             if (settings.contains("images")) {
                 List<Json> settingsImages = settings.jsons("images");

--- a/src/main/java/io/slingr/service/pdf/workers/MergeDocumentsWorker.java
+++ b/src/main/java/io/slingr/service/pdf/workers/MergeDocumentsWorker.java
@@ -6,6 +6,8 @@ import io.slingr.services.services.Files;
 import io.slingr.services.services.rest.DownloadedFile;
 import io.slingr.services.utils.Json;
 import io.slingr.services.ws.exchange.FunctionRequest;
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.io.RandomAccessReadBuffer;
 import org.apache.pdfbox.multipdf.PDFMergerUtility;
 import org.apache.pdfbox.multipdf.Splitter;
 import org.apache.pdfbox.pdmodel.PDDocument;
@@ -48,7 +50,7 @@ public class MergeDocumentsWorker extends PdfWorker {
                     String fileId = doc.string("file");
                     DownloadedFile downloadedFile = files.download(fileId);
                     InputStream is = downloadedFile.getFile();
-                    PDDocument pdf = PDDocument.load(is);
+                    PDDocument pdf = Loader.loadPDF(new RandomAccessReadBuffer(is));
                     List<PDDocument> splitDoc = splitter.split(pdf);
                     int i = 1;
                     for (PDDocument page : splitDoc) {

--- a/src/main/java/io/slingr/service/pdf/workers/ReplaceImagesWorker.java
+++ b/src/main/java/io/slingr/service/pdf/workers/ReplaceImagesWorker.java
@@ -6,6 +6,8 @@ import io.slingr.services.services.Events;
 import io.slingr.services.services.Files;
 import io.slingr.services.utils.Json;
 import io.slingr.services.ws.exchange.FunctionRequest;
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.io.RandomAccessReadBuffer;
 import org.apache.pdfbox.pdmodel.PDDocument;
 
 import java.io.File;
@@ -30,7 +32,7 @@ public class ReplaceImagesWorker extends PdfImageWorker {
         try {
             if (data.contains("settings")) {
                 InputStream is = files.download(fileId).getFile();
-                PDDocument pdf = PDDocument.load(is);
+                PDDocument pdf = Loader.loadPDF(new RandomAccessReadBuffer(is));
                 Json settings = data.json("settings");
                 if (settings.contains("images")) {
                     List<Json> settingsImages = settings.jsons("images");

--- a/src/main/java/io/slingr/service/pdf/workers/SplitDocumentWorker.java
+++ b/src/main/java/io/slingr/service/pdf/workers/SplitDocumentWorker.java
@@ -8,6 +8,8 @@ import io.slingr.services.services.Files;
 import io.slingr.services.utils.Json;
 import io.slingr.services.ws.exchange.FunctionRequest;
 import org.apache.commons.lang.StringUtils;
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.io.RandomAccessReadBuffer;
 import org.apache.pdfbox.multipdf.PDFMergerUtility;
 import org.apache.pdfbox.multipdf.Splitter;
 import org.apache.pdfbox.pdmodel.PDDocument;
@@ -45,7 +47,7 @@ public class SplitDocumentWorker extends PdfWorker {
             PDFMergerUtility merger = new PDFMergerUtility();
             Splitter splitter = new Splitter();
             InputStream is = files.download(fileId).getFile();
-            PDDocument pdf = PDDocument.load(is);
+            PDDocument pdf = Loader.loadPDF(new RandomAccessReadBuffer(is));
             List<PDDocument> splitDoc = splitter.split(pdf);
             if (!splitDoc.isEmpty()) {
                 for (int i = 0; i < splitDoc.size(); i += interval) {

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,4 +1,5 @@
-log4j.rootLogger=info, ${ROOT_LOGGER}
+# Root logger option
+log4j.rootLogger=INFO, stdout
 
 log4j.appender.logentries=com.logentries.log4j.LogentriesAppender
 log4j.appender.logentries.layout=io.slingr.services.services.logs.ServiceLayout

--- a/src/test/java/io/slingr/service/pdf/PdfTest.java
+++ b/src/test/java/io/slingr/service/pdf/PdfTest.java
@@ -1,0 +1,63 @@
+package io.slingr.service.pdf;
+
+import io.slingr.services.services.exchange.Parameter;
+import io.slingr.services.utils.Json;
+import io.slingr.services.utils.tests.ServiceTests;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+
+public class PdfTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(PdfTest.class);
+
+    private static ServiceTests test;
+
+    @BeforeClass
+    public static void init() throws Exception {
+        test = ServiceTests.start(new io.slingr.service.pdf.Runner(), "test.properties");
+    }
+
+    @Test
+    public void testGeneratePdf() {
+        logger.info("-- INIT --");
+        final Json req = Json.map();
+
+        String headerTemplate = "<!DOCTYPE html>  <html>    <head></head>    <body>      <h2>** Good News: ${title}</h2>      Page <span id='page'></span> of      <span id='topage'></span>         <hr />      <script>         var vars={};        var x=window.location.search.substring(1).split('&');        for (var i in x) {          var z=x[i].split('=',2);          vars[z[0]] = unescape(z[1]);        }        document.getElementById('page').innerHTML = vars.page;        document.getElementById('topage').innerHTML = vars.topage;      </script>     </body>  </html>";
+
+        Json headerData = Json.map().set("title", "Page title!!");
+        String footerTemplate = "<!DOCTYPE html><html><body><h3>Page here ## ${name}</h3></body></html>";
+        Json footerData = Json.map().set("name", "User Name");
+
+        req.set("template", "<html><body><h1>${title}</h1><#list items as item><tr><td>${item.name}</td></tr></#list></body></html>");
+        req.set("data", Json.map()
+                .set("title", "Example PDF")
+                .set("items", List.of(
+                        Json.map().set("name", "Item 1"),
+                        Json.map().set("name", "Item 2"))));
+        req.set("settings", Json.map()
+                .set("name", "MyPdfFile")
+                .set("pageSize", "letter")
+                .set("headerTemplate", headerTemplate)
+                .set("headerData", headerData)
+                .set("footerTemplate", footerTemplate)
+                .set("footerData", footerData));
+
+        // test request
+        Json res = test.executeFunction("generatePdf", req);
+        assertNotNull(res);
+        logger.info(res.toString());
+        assertFalse(res.is(Parameter.EXCEPTION_FLAG));
+        // body is 'ok'
+        assertNotNull(res.string("status"));
+        assertEquals("ok", res.string("status"));
+
+        logger.info("-- END --");
+    }
+}

--- a/src/test/java/io/slingr/service/pdf/processors/PdfGeneratorTest.java
+++ b/src/test/java/io/slingr/service/pdf/processors/PdfGeneratorTest.java
@@ -1,6 +1,5 @@
-package io.slingr.service.pdf;
+package io.slingr.service.pdf.processors;
 
-import io.slingr.service.pdf.processors.PdfHeaderFooterHandler;
 import io.slingr.services.utils.FilesUtils;
 import io.slingr.services.utils.Json;
 import org.junit.Assert;

--- a/src/test/resources/test.properties
+++ b/src/test/resources/test.properties
@@ -1,0 +1,21 @@
+# System properties
+_service_name=pdf
+_app_name=test1
+_environment=dev
+_pod_id=id
+_profile=default
+_custom_domain=
+
+_debug=true
+_local_deployment=true
+
+_webservices_port=10000
+_base_domain=localhost:8000
+_extension_broker_api=http://localhost:2255/api
+_token=test1/dev/pdf
+
+# Service specific properties
+_service_config={"maxThreadPool": 3, "downloadImages": "false"}
+
+# Testing mode enabled
+_testing_mode=true


### PR DESCRIPTION
Pull-request for issue https://github.com/slingr-stack/platform/issues/15600 created by @pasaperez-slingr 

## What it does?

Migrate the pdf-service to use java 17. Update dependencies.
Now the pom.xml is less dependent on the build options. It only takes care of the service specific code.
Add test.

## How to test it?

You can run the test. Make sure to configurate Java 17 on the project.

Test with any service in develop branch.

Remember to use this [checklist](https://docs.google.com/document/d/139rKhIsvpT3yBSB88BBZfy03fD_Sried0bVwIWVaHJk/edit?usp=sharing) for the review.

## Technical notes

There aren't technical notes

## Deployment notes

Create a new tag and build in each version.