### PR TITLE
Add image quality settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ You can set specific properties in document.
 
 **footerData** data used in footer template.
 
+**imageDpi:** when embedding images scale them down to this dpi. Default value is `600`. You can check `wkhtmltopdf` for more options.
+
+**imageQuality:** when jpeg compressing images use this quality.  Default value is `94`. You can check `wkhtmltopdf` for more options.
+
+**lowquality:** generates lower quality pdf/ps. Useful to shrink the result document space. Default value is `false`. You can check `wkhtmltopdf` for more options.
+
+
 ## Generated PDF
 
 Generated PDF is returned as a file structure.

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <packaging>jar</packaging>
     <properties>
         <!-- Slingr versions -->
-        <slingr.slingr-service.version>1.4.0</slingr.slingr-service.version>
+        <slingr.slingr-service.version>1.5.5</slingr.slingr-service.version>
         <!-- Dependency versions -->
         <freemarker.version>2.3.32</freemarker.version>
         <pdfbox.version>3.0.1</pdfbox.version>

--- a/public_pom.xml
+++ b/public_pom.xml
@@ -13,7 +13,7 @@
     <packaging>jar</packaging>
     <properties>
         <!-- Slingr versions -->
-        <slingr.slingr-service.version>1.4.0</slingr.slingr-service.version>
+        <slingr.slingr-service.version>1.5.5</slingr.slingr-service.version>
         <!-- Dependency versions -->
         <freemarker.version>2.3.32</freemarker.version>
         <pdfbox.version>3.0.1</pdfbox.version>

--- a/src/main/java/io/slingr/service/pdf/Pdf.java
+++ b/src/main/java/io/slingr/service/pdf/Pdf.java
@@ -43,7 +43,6 @@ import java.util.concurrent.TimeUnit;
 
 @SlingrService(name = "pdf")
 public class Pdf extends Service {
-
     private static final String SERVICE_NAME = "pdf";
     private final Logger logger = LoggerFactory.getLogger(Pdf.class);
 

--- a/src/main/java/io/slingr/service/pdf/processors/PdfEngine.java
+++ b/src/main/java/io/slingr/service/pdf/processors/PdfEngine.java
@@ -15,74 +15,73 @@ import java.io.*;
 import java.util.*;
 
 public class PdfEngine {
-
     private final Logger logger = LoggerFactory.getLogger(PdfEngine.class);
 
     private final String template;
-    List<String> commandParams;
+    private final List<String> commandParams;
     private String sourceTmpFile;
     private String targetTmpFile;
     private final String fileName;
-
     private final String headerTmpFile;
     private final String footerTmpFile;
     public static boolean downloadImages;
 
-
     public PdfEngine(String tpl, Json settings, boolean downloadImages) throws IOException, TemplateException {
-
         template = tpl;
         commandParams = new ArrayList<>();
         commandParams.add("/usr/bin/wkhtmltopdf");
-
         if (settings == null) {
             settings = Json.map();
         }
-
         this.headerTmpFile = this.addFileCommandParams(commandParams, settings.string("headerTemplate"), settings.json("headerData"), "--header-html");
         this.footerTmpFile = this.addFileCommandParams(commandParams, settings.string("footerTemplate"), settings.json("footerData"), "--footer-html");
-
         String pageSize = settings.string("pageSize");
         if (StringUtils.isBlank(pageSize)) {
             pageSize = "A4";
         }
         commandParams.add("--page-size");
         commandParams.add(pageSize);
-
         if (downloadImages){
             commandParams.add("--enable-local-file-access");
         }
-
         String orientation = settings.string("orientation");
         if (StringUtils.isNotBlank(orientation) && orientation.equalsIgnoreCase("landscape")) {
             commandParams.add("--orientation");
             commandParams.add("Landscape");
         }
-
         Integer marginBottom = settings.integer("marginBottom");
         if (marginBottom != null) {
             commandParams.add("--margin-bottom");
             commandParams.add(Integer.toString(marginBottom));
         }
-
         Integer marginLeft = settings.integer("marginLeft");
         if (marginLeft != null) {
             commandParams.add("--margin-left");
             commandParams.add(Integer.toString(marginLeft));
         }
-
         Integer marginRight = settings.integer("marginRight");
         if (marginRight != null) {
             commandParams.add("--margin-right");
             commandParams.add(Integer.toString(marginRight));
         }
-
         Integer marginTop = settings.integer("marginTop");
         if (marginTop != null) {
             commandParams.add("--margin-top");
             commandParams.add(Integer.toString(marginTop));
         }
-
+        Integer imageDpi = settings.integer("imageDpi");
+        if (imageDpi != null) {
+            commandParams.add("--image-dpi");
+            commandParams.add(Integer.toString(imageDpi));
+        }
+        Integer imageQuality = settings.integer("imageDpi");
+        if (imageQuality != null) {
+            commandParams.add("--image-quality");
+            commandParams.add(Integer.toString(imageQuality));
+        }
+        if (settings.bool("lowquality") != null) {
+            commandParams.add("--lowquality");
+        }
         String fn = settings.string("name");
         if (StringUtils.isBlank(fn)) {
             fileName = "pdf-" + new Date().getTime();
@@ -154,7 +153,6 @@ public class PdfEngine {
         if (deleteH && deleteT && deleteF && deleteS) {
             logger.info("Cleaning temporal files");
         }
-
         String TMP_PATH = "/tmp";
         File tmpFolder = new File(TMP_PATH);
         if (tmpFolder.exists() && tmpFolder.isDirectory()) {
@@ -162,7 +160,7 @@ public class PdfEngine {
             File[] tmpFiles = tmpFolder.listFiles(filter);
             if (tmpFiles != null) {
                 for (File tmpFile : tmpFiles) {
-                    if (tmpFile.delete())  logger.info("Deleted: " + tmpFile.getName());
+                    if (tmpFile.delete()) logger.info("Deleted: {}", tmpFile.getName());
                 }
             }
             logger.info(".tmp files deleted from the /tmp folder.");

--- a/src/main/java/io/slingr/service/pdf/processors/PdfFillForm.java
+++ b/src/main/java/io/slingr/service/pdf/processors/PdfFillForm.java
@@ -27,8 +27,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class PdfFillForm {
-
     private final Logger logger = LoggerFactory.getLogger(PdfFillForm.class);
+
     private final Map<String, String> fonts;
     private final AppLogs appLogger;
 
@@ -149,9 +149,8 @@ public class PdfFillForm {
 
     private Color hex2Rgb(String colorStr) {
         StringUtils.replace(colorStr, "#", "");
-        return new DeviceRgb(
-                Integer.valueOf(colorStr.substring(1, 3), 16),
-                Integer.valueOf(colorStr.substring(3, 5), 16),
-                Integer.valueOf(colorStr.substring(5, 7), 16));
+        return new DeviceRgb(Integer.valueOf(colorStr.substring(1, 3), 16),
+                             Integer.valueOf(colorStr.substring(3, 5), 16),
+                             Integer.valueOf(colorStr.substring(5, 7), 16));
     }
 }

--- a/src/main/java/io/slingr/service/pdf/processors/PdfHeaderFooterHandler.java
+++ b/src/main/java/io/slingr/service/pdf/processors/PdfHeaderFooterHandler.java
@@ -21,6 +21,7 @@ import java.io.*;
 import java.util.*;
 
 public class PdfHeaderFooterHandler {
+    private static final Logger logger = LoggerFactory.getLogger(PdfHeaderFooterHandler.class);
 
     public static final String HEADER = "header";
     public static final String FOOTER = "footer";
@@ -32,10 +33,8 @@ public class PdfHeaderFooterHandler {
     public static final String TEMP_FOOTER_PATH = "tempFooterPath";
     public static final String HTML = "html";
     public static final String DATA = "data";
-    private static final Logger logger = LoggerFactory.getLogger(PdfHeaderFooterHandler.class);
     private final Map<String, String> tempFiles = new HashMap<>();
     public static boolean downloadImages;
-
 
     public String setHeaderWithImage(InputStream report, String headerTemplate, float hHeight, float hWidth, String footerTemplate, float fHeight, float fWidth) {
         if (headerTemplate != null) {
@@ -226,7 +225,7 @@ public class PdfHeaderFooterHandler {
     public void cleanGeneratedFiles() {
         for (String key : tempFiles.keySet()) {
             if (tempFiles.get(key) != null) {
-                logger.info("Cleaning files: " + (new File(tempFiles.get(key))).delete());
+                logger.info("Cleaning files: {}", (new File(tempFiles.get(key))).delete());
             }
         }
     }

--- a/src/main/java/io/slingr/service/pdf/workers/FillFormWorker.java
+++ b/src/main/java/io/slingr/service/pdf/workers/FillFormWorker.java
@@ -16,7 +16,6 @@ import java.io.IOException;
 import java.io.InputStream;
 
 public class FillFormWorker extends PdfWorker {
-
     private final Logger logger = LoggerFactory.getLogger(FillFormWorker.class);
 
     public FillFormWorker(Events events, Files files, AppLogs appLogger, FunctionRequest request) {

--- a/src/main/java/io/slingr/service/pdf/workers/MergeDocumentsWorker.java
+++ b/src/main/java/io/slingr/service/pdf/workers/MergeDocumentsWorker.java
@@ -21,7 +21,6 @@ import java.io.InputStream;
 import java.util.List;
 
 public class MergeDocumentsWorker extends PdfWorker {
-
     private final Logger logger = LoggerFactory.getLogger(MergeDocumentsWorker.class);
 
     public MergeDocumentsWorker(Events events, Files files, AppLogs appLogger, FunctionRequest request) {

--- a/src/main/java/io/slingr/service/pdf/workers/ReplaceHeaderAndFooterWorker.java
+++ b/src/main/java/io/slingr/service/pdf/workers/ReplaceHeaderAndFooterWorker.java
@@ -17,7 +17,6 @@ import java.io.InputStream;
 import java.util.Objects;
 
 public class ReplaceHeaderAndFooterWorker extends PdfWorker {
-
     private final Logger logger = LoggerFactory.getLogger(ReplaceHeaderAndFooterWorker.class);
 
     private static final String IMAGE_ID = "imageId";

--- a/src/main/java/io/slingr/service/pdf/workers/SplitDocumentWorker.java
+++ b/src/main/java/io/slingr/service/pdf/workers/SplitDocumentWorker.java
@@ -25,7 +25,6 @@ import java.util.List;
 
 
 public class SplitDocumentWorker extends PdfWorker {
-
     private final Logger logger = LoggerFactory.getLogger(SplitDocumentWorker.class);
 
     public SplitDocumentWorker(Events events, Files files, AppLogs appLogger, FunctionRequest request) {


### PR DESCRIPTION
Agrega parametros para poder comprimir (reducir la calidad) de las imagenes.
Son parametros que se pasan directamente al CLI de `wkhtmltopdf` .

Se puede probar alternando los parametros de settings.
Hay una prueba en tarzan (testpackages)
En la siguiente acción se pueden variar los distintos parametros.
https://testpackages.tarzan.io/dev/builder/#model/entities/65ea2b96fafaa16ca0a73713/actions/65ea2bab697af86e19006e1a

En la view se puede crear nuevos pdf con la imagen en un link:https://testpackages.tarzan.io/dev/runtime/#views/65ea2c1ffafaa16ca0a73a8d

Link a imagen de prueba: https://testpackages.tarzan.io/dev/runtime/api/files/public/images/1720876856606977321170532933798.jpg

En los ultimos records de la view se pueden ver pdfs generados con estos cambios. Con los ultimos cambios se pudo ver una disminución de 4.2 Mb a 68 Kb de tamaño de archivo. 