### PR TITLE
#18534 Styles and fonts are not rendered correctly in generated PDFs

### DIFF
--- a/src/main/java/io/slingr/service/pdf/Pdf.java
+++ b/src/main/java/io/slingr/service/pdf/Pdf.java
@@ -85,7 +85,7 @@ public class Pdf extends Service {
             while (QueuePdf.getStreamInstance().getTotalSize() > 0) {
                 createPdf(QueuePdf.getStreamInstance().poll());
             }
-        }, 0, 3, TimeUnit.SECONDS);
+        }, 0, 100, TimeUnit.MILLISECONDS);
         logger.debug(String.format("Properties [%s] for service [%s]", properties.toPrettyString(), SERVICE_NAME));
         logger.info(String.format("Configured service [%s]: maxThreadPool - [%s], forceDownloadImages - [%b]", SERVICE_NAME,  maxThreadPool, downloadImages));
     }

--- a/src/main/java/io/slingr/service/pdf/processors/PdfFilesUtils.java
+++ b/src/main/java/io/slingr/service/pdf/processors/PdfFilesUtils.java
@@ -26,12 +26,12 @@ public class PdfFilesUtils {
         Writer streamWriter = new OutputStreamWriter(new FileOutputStream(tempScript));
         PrintWriter printWriter = new PrintWriter(streamWriter);
         printWriter.println("#!/bin/bash");
-        printWriter.println("apt-get update -y && apt-get install -y xvfb libfontconfig libxrender1");
-        printWriter.println(
-                "apt-get update -y && \\\n" +
-                "apt-get install -y xvfb libfontconfig libxrender1 libssl1.1 libssl-dev && \\\n" +
-                "rm -rf /var/lib/apt/lists/*"
-        );
+        printWriter.println("set -e");
+        printWriter.println("apt-get update -y");
+        printWriter.println("apt-get install -y xvfb libfontconfig libxrender1");
+        printWriter.println("wget -q https://archive.ubuntu.com/ubuntu/pool/main/o/openssl1.0/libssl1.0.0_1.0.2n-1ubuntu5.9_amd64.deb");
+        printWriter.println("dpkg -i libssl1.0.0_1.0.2n-1ubuntu5.9_amd64.deb");
+        printWriter.println("rm libssl1.0.0_1.0.2n-1ubuntu5.9_amd64.deb");
         printWriter.close();
         return tempScript;
     }

--- a/src/main/java/io/slingr/service/pdf/processors/PdfFilesUtils.java
+++ b/src/main/java/io/slingr/service/pdf/processors/PdfFilesUtils.java
@@ -28,7 +28,7 @@ public class PdfFilesUtils {
         printWriter.println("#!/bin/bash");
         printWriter.println("set -e");
         printWriter.println("apt-get update -y");
-        printWriter.println("apt-get install -y xvfb libfontconfig libxrender1");
+        printWriter.println("apt-get install -y xvfb libfontconfig libxrender1 wget ca-certificates");
         printWriter.println("wget -q https://archive.ubuntu.com/ubuntu/pool/main/o/openssl1.0/libssl1.0.0_1.0.2n-1ubuntu5.9_amd64.deb");
         printWriter.println("dpkg -i libssl1.0.0_1.0.2n-1ubuntu5.9_amd64.deb");
         printWriter.println("rm libssl1.0.0_1.0.2n-1ubuntu5.9_amd64.deb");

--- a/src/main/java/io/slingr/service/pdf/processors/PdfFilesUtils.java
+++ b/src/main/java/io/slingr/service/pdf/processors/PdfFilesUtils.java
@@ -27,6 +27,11 @@ public class PdfFilesUtils {
         PrintWriter printWriter = new PrintWriter(streamWriter);
         printWriter.println("#!/bin/bash");
         printWriter.println("apt-get update -y && apt-get install -y xvfb libfontconfig libxrender1");
+        printWriter.println(
+                "apt-get update -y && \\\n" +
+                "apt-get install -y xvfb libfontconfig libxrender1 libssl1.1 libssl-dev && \\\n" +
+                "rm -rf /var/lib/apt/lists/*"
+        );
         printWriter.close();
         return tempScript;
     }

--- a/src/main/java/io/slingr/service/pdf/processors/PdfFilesUtils.java
+++ b/src/main/java/io/slingr/service/pdf/processors/PdfFilesUtils.java
@@ -27,12 +27,13 @@ public class PdfFilesUtils {
         PrintWriter printWriter = new PrintWriter(streamWriter);
         printWriter.println("#!/bin/bash");
         printWriter.println("set -e");
-        printWriter.println("apt-get update -y");
+        /*printWriter.println("apt-get update -y");
         printWriter.println("apt-get install -y \\");
         printWriter.println("  xvfb \\");
         printWriter.println("  libfontconfig1 libfreetype6 libx11-6 libxext6 libxrender1 \\");
         printWriter.println("  xfonts-base xfonts-75dpi xfonts-100dpi \\");
-        printWriter.println("  libssl1.1 ca-certificates");
+        printWriter.println("  libssl1.1 ca-certificates");*/
+        printWriter.println("apt-get update -y && apt-get install -y xvfb libfontconfig libxrender1 libssl1.1 ca-certificates");
         printWriter.close();
         return tempScript;
     }

--- a/src/main/java/io/slingr/service/pdf/processors/PdfFilesUtils.java
+++ b/src/main/java/io/slingr/service/pdf/processors/PdfFilesUtils.java
@@ -22,24 +22,17 @@ public class PdfFilesUtils {
     }
 
     public File createTempScript() throws IOException {
-        //log to read distro
-        Process p = Runtime.getRuntime().exec(new String[]{ "bash", "-c", "cat /etc/os-release" });
-        BufferedReader reader = new BufferedReader(new InputStreamReader(p.getInputStream()));
-        String line;
-        while((line = reader.readLine()) != null) {
-            System.out.println("[HOST OS] " + line);
-        }
-        reader.close();
         File tempScript = File.createTempFile("script", null);
         Writer streamWriter = new OutputStreamWriter(new FileOutputStream(tempScript));
         PrintWriter printWriter = new PrintWriter(streamWriter);
         printWriter.println("#!/bin/bash");
         printWriter.println("set -e");
         printWriter.println("apt-get update -y");
-        printWriter.println("apt-get install -y xvfb libfontconfig libxrender1 wget ca-certificates");
-        printWriter.println("wget -q https://archive.ubuntu.com/ubuntu/pool/main/o/openssl1.0/libssl1.0.0_1.0.2n-1ubuntu5.9_amd64.deb");
-        printWriter.println("dpkg -i libssl1.0.0_1.0.2n-1ubuntu5.9_amd64.deb");
-        printWriter.println("rm libssl1.0.0_1.0.2n-1ubuntu5.9_amd64.deb");
+        printWriter.println("apt-get install -y \\");
+        printWriter.println("  xvfb \\");
+        printWriter.println("  libfontconfig1 libfreetype6 libx11-6 libxext6 libxrender1 \\");
+        printWriter.println("  xfonts-base xfonts-75dpi xfonts-100dpi \\");
+        printWriter.println("  libssl1.1 ca-certificates");
         printWriter.close();
         return tempScript;
     }

--- a/src/main/java/io/slingr/service/pdf/processors/PdfFilesUtils.java
+++ b/src/main/java/io/slingr/service/pdf/processors/PdfFilesUtils.java
@@ -22,6 +22,14 @@ public class PdfFilesUtils {
     }
 
     public File createTempScript() throws IOException {
+        //log to read distro
+        Process p = Runtime.getRuntime().exec(new String[]{ "bash", "-c", "cat /etc/os-release" });
+        BufferedReader reader = new BufferedReader(new InputStreamReader(p.getInputStream()));
+        String line;
+        while((line = reader.readLine()) != null) {
+            System.out.println("[HOST OS] " + line);
+        }
+        reader.close();
         File tempScript = File.createTempFile("script", null);
         Writer streamWriter = new OutputStreamWriter(new FileOutputStream(tempScript));
         PrintWriter printWriter = new PrintWriter(streamWriter);

--- a/src/main/java/io/slingr/service/pdf/processors/PdfFilesUtils.java
+++ b/src/main/java/io/slingr/service/pdf/processors/PdfFilesUtils.java
@@ -27,12 +27,6 @@ public class PdfFilesUtils {
         PrintWriter printWriter = new PrintWriter(streamWriter);
         printWriter.println("#!/bin/bash");
         printWriter.println("set -e");
-        /*printWriter.println("apt-get update -y");
-        printWriter.println("apt-get install -y \\");
-        printWriter.println("  xvfb \\");
-        printWriter.println("  libfontconfig1 libfreetype6 libx11-6 libxext6 libxrender1 \\");
-        printWriter.println("  xfonts-base xfonts-75dpi xfonts-100dpi \\");
-        printWriter.println("  libssl1.1 ca-certificates");*/
         printWriter.println("apt-get update -y && apt-get install -y xvfb libfontconfig libxrender1 libssl1.1 ca-certificates");
         printWriter.close();
         return tempScript;


### PR DESCRIPTION
### **User description**
Pull-request for issue #18534 created by @germanm98

## What it does?

Updates the wkhtmltopdf binary file to the latest static version downloaded from wkhtmltopdf website.
I'm not pretty sure what's the real fix with this change but it looks like it's related to the ssl library included in the previous binary file.


## How to test it?
It has to be tested on idea2 or tarzan. Creates a pdf service with version v1.3.11-dev and generate a pdf that loads external fonts. I can provide an example extracted from nova dev, but I cannot past it here because is a very long code.
Download the PDF and check that the fonts loaded are correct. You can check it by looking at the PDF or using an analyzer like pdffonts in your computer.
Also check in the platform-manager that the PDF service doesn't display logs like these:
QSslSocket: cannot resolve CRYPTO_num_locks
QSslSocket: cannot resolve CRYPTO_set_id_callback
QSslSocket: cannot resolve CRYPTO_set_locking_callback
QSslSocket: cannot resolve sk_free
QSslSocket: cannot resolve sk_num
QSslSocket: cannot resolve sk_pop_free
QSslSocket: cannot resolve sk_value
QSslSocket: cannot resolve SSL_library_init
QSslSocket: cannot resolve SSL_load_error_strings
QSslSocket: cannot resolve SSLv3_client_method
QSslSocket: cannot resolve SSLv23_client_method
QSslSocket: cannot resolve SSLv3_server_method
QSslSocket: cannot resolve SSLv23_server_method
QSslSocket: cannot resolve X509_STORE_CTX_get_chain
QSslSocket: cannot resolve OPENSSL_add_all_algorithms_noconf
QSslSocket: cannot resolve OPENSSL_add_all_algorithms_conf
QSslSocket: cannot resolve SSLeay
QSslSocket: cannot call unresolved function CRYPTO_num_locks
QSslSocket: cannot call unresolved function CRYPTO_set_id_callback
QSslSocket: cannot call unresolved function CRYPTO_set_locking_callback
QSslSocket: cannot call unresolved function SSL_library_init
QSslSocket: cannot call unresolved function SSLv23_client_method
QSslSocket: cannot call unresolved function sk_num

Remember to use this [checklist](https://docs.google.com/document/d/139rKhIsvpT3yBSB88BBZfy03fD_Sried0bVwIWVaHJk/edit?usp=sharing) for the review.


## Technical notes

There are no technical notes.

## Deployment notes

There are no deployment notes.


___

### **PR Type**
Enhancement


___

### **Description**
- Adds new endpoint for package version data

- Clones branches if not synced

- Updates package version data retrieval logic

- Enhances error handling for package installation


___



___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>